### PR TITLE
Add support for POST requests through http proxy

### DIFF
--- a/cmk/gui/plugins/wato/active_checks.py
+++ b/cmk/gui/plugins/wato/active_checks.py
@@ -1457,6 +1457,7 @@ def _valuespec_active_checks_http():
                                                     ("DELETE", "DELETE"),
                                                     ("HEAD", "HEAD"),
                                                     ("CONNECT", "CONNECT"),
+                                                    ("CONNECT:POST", "CONNECT:POST"),
                                                     ("PROPFIND", "PROPFIND"),
                                                 ],
                                             ),


### PR DESCRIPTION
## General information
For http communication through an http proxy, first an CONNECT request to the proxy is send. That the request like GET/POST is send through the proxy to the target system.

## Bug reports
cmk is not able to send POST requests through an http proxy as the CONNECT method is required to use the proxy. check_http supports the CONNECT:POST method for this, which is not available in wato at this time.

## Proposed changes
Add the method CONNECT:POST to wato. Already supported by check_http (see https://github.com/monitoring-plugins/monitoring-plugins/pull/1476)